### PR TITLE
Cache forever

### DIFF
--- a/app/app/settings/base.py
+++ b/app/app/settings/base.py
@@ -191,7 +191,9 @@ if not GITHUB_API_TOKEN:
           " be rate-limited at 60 requests per hour which may result in"
           " errors.")
 
-CACHE_TIMEOUT = 60 * 60  # 1 hour
+# Cache forever unless requested
+# (automated by GH workflow in galaxyproject/galaxy_codex)
+CACHE_TIMEOUT = None
 
 # Internationalization
 # https://docs.djangoproject.com/en/3.2/topics/i18n/


### PR DESCRIPTION
Cache lab pages forever, until requested with `&cache=false`
This will be automated with workflow in [galaxyproject/galaxy_codex](https://github.com/galaxyproject/galaxy_codex) when changes are made to a Lab's content.