### PR TITLE
Audit tool links

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,14 @@ def parse_bold_xlsx(
     return results
 ```
 
+### Line-wrapping of long strings
+
+```py
+TEST_VALID_TOOL_URL = (
+    f'{TEST_GALAXY_SERVER_URL}/?'
+    'tool_id=toolshed.g2.bx.psu.edu%2Frepos%2Fgalaxyp%2Fdiann%2Fdiann')
+```
+
 ### Example of poor line-wrapping
 
 ```python
@@ -124,4 +132,6 @@ Make sure that no trailing whitespace remains, including lines which contain not
 Where appropriate, declare string, int and float values as constants at the top of the script, below imports. This should only be done where it improves the readability of code. Paths, URLs and "magic numbers" should always be declared in this way, but not dictionary keys.
 
 ## Enforcement
+
 Claude will automatically ensure all code follows these guidelines before writing or modifying any Python files.
+After writing python code, run flake8 linter to ensure compliance. If flake8 is not installed, add it to the project's requirements.txt and pip-install it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,7 @@ result = (
 - Run linting before committing code
 
 ### Example of Well-Formatted Code
+
 ```python
 def parse_bold_xlsx(
     self,
@@ -104,6 +105,19 @@ def parse_bold_xlsx(
         
     return results
 ```
+
+### Example of poor line-wrapping
+
+```python
+# This is ugly
+def parse_bold_xlsx(self, path: Path,
+                    results: dict = None) -> dict[str, list]:
+```
+
+
+### Whitespace
+
+Make sure that no trailing whitespace remains, including lines which contain nothing but whitespace.
 
 ### Use of constants
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,113 @@
+# Claude Code Guidelines
+
+## Python Code Style Requirements
+
+### PEP 8 Compliance
+- All Python code must be PEP 8 compliant
+- **Line length: Maximum 79 characters** (strict enforcement)
+- Use 4 spaces for indentation (no tabs)
+- Follow naming conventions:
+  - Functions and variables: `snake_case`
+  - Classes: `PascalCase`  
+  - Constants: `UPPER_CASE`
+
+### Code Quality Standards
+- Remove trailing whitespace from all lines
+- End files with a single newline
+- Use meaningful variable names
+- Add type hints where appropriate
+- Follow existing import organization patterns
+
+### Line Length Management
+When lines exceed 79 characters, use these strategies:
+1. **Function calls**: Break at commas, align arguments
+```python
+# Good
+result = some_function(
+    argument_one,
+    argument_two,
+    argument_three
+)
+```
+
+2. **Long strings**: Use parentheses for implicit concatenation
+```python
+# Good
+message = (
+    "This is a very long message that needs to be "
+    "split across multiple lines"
+)
+```
+
+3. **Import statements**: Use parentheses for multiple imports
+```python
+# Good
+from src.bold.id_engine import (
+    BoldSearch,
+    BOLDIGGER_NO_MATCH_STR,
+    BOLDIGGER_OUTPUT_DIRNAME,
+)
+```
+
+4. **Method chaining**: Break at dots
+```python
+# Good
+result = (
+    some_object
+    .method_one()
+    .method_two()
+    .method_three()
+)
+```
+
+### Testing Standards
+- Test files must also follow PEP 8 guidelines
+- Test method names should be descriptive
+- Use setUp/tearDown methods appropriately
+- Mock external dependencies in tests
+
+### Tools
+- Use `flake8` or `black` for automatic formatting
+- Configure your editor to show line length indicators at 79 characters
+- Run linting before committing code
+
+### Example of Well-Formatted Code
+```python
+def parse_bold_xlsx(
+    self,
+    path: Path,
+    results: dict = None,
+) -> dict[str, list]:
+    """Parse BOLDigger3 XLSX output with proper formatting."""
+    if results is None:
+        results = {}
+    
+    df = pd.read_excel(path)
+    
+    for _, row in df.iterrows():
+        query_id = row['id']
+        
+        # Handle long conditional statements
+        if (
+            row.get('phylum') == BOLDIGGER_NO_MATCH_STR
+            or pd.isna(row.get('processid'))
+        ):
+            continue
+            
+        # Handle long dictionary definitions
+        hit = {
+            "hit_id": process_id,
+            "taxonomic_identification": taxonomic_identification,
+            "identity": row.get('pct_identity'),
+            "url": BOLD_RECORD_BASE_URL + process_id,
+        }
+        
+    return results
+```
+
+### Use of constants
+
+Where appropriate, declare string, int and float values as constants at the top of the script, below imports. This should only be done where it improves the readability of code. Paths, URLs and "magic numbers" should always be declared in this way, but not dictionary keys.
+
+## Enforcement
+Claude will automatically ensure all code follows these guidelines before writing or modifying any Python files.

--- a/app/app/settings/base.py
+++ b/app/app/settings/base.py
@@ -15,7 +15,8 @@ BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
-CLI_DEV = True  # Don't cache anything
+CLI_DEV = False
+NOCACHE = True
 AUTH_USER_MODEL = 'labs.User'
 SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY') or "secretkey"
 SILENCED_SYSTEM_CHECKS = ['django_recaptcha.recaptcha_test_key_error']

--- a/app/app/settings/base.py
+++ b/app/app/settings/base.py
@@ -200,6 +200,9 @@ CACHE_TIMEOUT = None
 # from the cache during a cache update.
 CACHE_UPDATE_RETAIN_DAYS = 30
 
+# Bioblend API response cache timeout (24 hours in development)
+BIOBLEND_CACHE_TTL = 60 * 60 * 24
+
 # Internationalization
 # https://docs.djangoproject.com/en/3.2/topics/i18n/
 

--- a/app/app/settings/cli.py
+++ b/app/app/settings/cli.py
@@ -11,6 +11,7 @@ from .base import *
 
 DEBUG = True
 CLI_DEV = True
+NOCACHE = True
 LAB_CONTENT_ROOT = os.environ.get('LAB_CONTENT_ROOT')
 if not LAB_CONTENT_ROOT:
     raise EnvironmentError('Env variable LAB_CONTENT_ROOT not set')

--- a/app/app/settings/prod.py
+++ b/app/app/settings/prod.py
@@ -42,6 +42,9 @@ STORAGES = {
     },
 }
 
+# Bioblend API response cache timeout (15 minutes in production)
+BIOBLEND_CACHE_TTL = 60 * 15
+
 SENTRY_DNS = os.getenv('SENTRY_DNS')
 if SENTRY_DNS:
     sentry_sdk.init(

--- a/app/app/settings/prod.py
+++ b/app/app/settings/prod.py
@@ -16,7 +16,7 @@ from .log import config
 validate.env()
 
 DEBUG = False
-CLI_DEV = False
+NOCACHE = False
 LOGGING = config.configure_logging(LOG_ROOT)
 print('Running with HOSTNAME:', HOSTNAME)
 

--- a/app/labs/audit.py
+++ b/app/labs/audit.py
@@ -1,0 +1,246 @@
+"""Tool auditing functionality using bioblend."""
+
+import logging
+import re
+import concurrent.futures
+from urllib.parse import parse_qs, urlparse
+from typing import List, Dict, Tuple
+
+from bioblend.galaxy import GalaxyInstance
+
+from django.template.loader import render_to_string
+
+logger = logging.getLogger('django')
+
+
+def extract_tool_links(html_content: str) -> List[Dict[str, str]]:
+    """Extract all tool links from HTML content.
+
+    Args:
+        html_content: The final rendered HTML template string
+
+    Returns:
+        List of dicts with 'url', 'tool_id', and 'link_text' keys
+    """
+    tool_links = []
+
+    # Find all href attributes that contain tool_id=
+    href_pattern = r'href="([^"]*tool_id=[^"]*)"'
+    matches = re.findall(href_pattern, html_content)
+
+    for url in matches:
+        # Parse the URL to extract tool_id
+        parsed_url = urlparse(url)
+        query_params = parse_qs(parsed_url.query)
+
+        if 'tool_id' in query_params:
+            tool_id = query_params['tool_id'][0]
+
+            # Find the link text by looking for the actual <a> tag
+            link_pattern = rf'<a[^>]*href="{re.escape(url)}"[^>]*>([^<]*)</a>'
+            link_match = re.search(link_pattern, html_content)
+            link_text = link_match.group(1).strip() if link_match else tool_id
+
+            tool_links.append({
+                'url': url,
+                'tool_id': tool_id,
+                'link_text': link_text or tool_id
+            })
+
+    return tool_links
+
+
+def check_tool_exists(
+    galaxy_url: str,
+    tool_id: str,
+    api_key: str = None
+) -> Tuple[str, bool, str]:
+    """Check if a tool exists on the Galaxy server.
+
+    Args:
+        galaxy_url: Base URL of the Galaxy server
+        tool_id: Tool ID to check
+        api_key: Optional API key for authentication
+
+    Returns:
+        Tuple of (tool_id, exists, error_message)
+    """
+    try:
+        # Create Galaxy instance
+        gi = GalaxyInstance(galaxy_url, key=api_key)
+
+        # Try to get tool information
+        try:
+            gi.tools.show_tool(tool_id)
+            return (tool_id, True, "")
+        except Exception as e:
+            # Tool doesn't exist or is not accessible
+            error_msg = str(e)
+            if "404" in error_msg or "not found" in error_msg.lower():
+                return (tool_id, False, "Tool not found")
+            else:
+                return (
+                    tool_id,
+                    False,
+                    f"Error checking tool: {error_msg}"
+                )
+
+    except Exception as e:
+        return (tool_id, False, f"Connection error: {str(e)}")
+
+
+def audit_tools_concurrent(
+    galaxy_url: str,
+    tool_links: List[Dict[str, str]],
+    api_key: str = None,
+    max_workers: int = 10
+) -> Dict[str, Dict]:
+    """Audit all tool links using ThreadPoolExecutor for concurrency.
+
+    Args:
+        galaxy_url: Base URL of the Galaxy server
+        tool_links: List of tool link dictionaries
+        api_key: Optional API key for authentication
+        max_workers: Maximum number of concurrent workers
+
+    Returns:
+        Dict mapping tool_id to audit results
+    """
+    if not tool_links:
+        return {}
+
+    results = {}
+
+    # Use ThreadPoolExecutor to run blocking bioblend calls concurrently
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=max_workers
+    ) as executor:
+        # Submit all tool checks
+        future_to_tool = {
+            executor.submit(
+                check_tool_exists,
+                galaxy_url,
+                tool_link['tool_id'],
+                api_key
+            ): tool_link
+            for tool_link in tool_links
+        }
+
+        # Collect results as they complete
+        for future in concurrent.futures.as_completed(future_to_tool):
+            tool_link = future_to_tool[future]
+            try:
+                tool_id, exists, error_message = future.result()
+                results[tool_id] = {
+                    'tool_id': tool_id,
+                    'url': tool_link['url'],
+                    'link_text': tool_link['link_text'],
+                    'exists': exists,
+                    'error': error_message
+                }
+            except Exception as e:
+                logger.error(
+                    f"Error checking tool {tool_link['tool_id']}: {e}"
+                )
+                results[tool_link['tool_id']] = {
+                    'tool_id': tool_link['tool_id'],
+                    'url': tool_link['url'],
+                    'link_text': tool_link['link_text'],
+                    'exists': False,
+                    'error': f"Unexpected error: {str(e)}"
+                }
+
+    return results
+
+
+def perform_template_audit(
+    template_str: str,
+    context: Dict,
+    request=None
+) -> Tuple[str, Dict]:
+    """Perform tool audit on template and return updated template and context.
+
+    Args:
+        template_str: The rendered HTML template string
+        context: Template context dictionary
+        request: Django request object (optional)
+
+    Returns:
+        Tuple of (updated_template_str, updated_context)
+    """
+
+    # Check if audit is requested
+    if not request or 'audit' not in request.GET:
+        return template_str, context
+
+    # Add audit flag to context
+    context['audit'] = True
+
+    # Extract tool links from the template
+    tool_links = extract_tool_links(template_str)
+
+    if tool_links:
+        galaxy_url = context.get('galaxy_base_url')
+        if galaxy_url:
+            try:
+                # Perform the audit
+                audit_results = audit_tools_concurrent(
+                    galaxy_url, tool_links
+                )
+
+                # Add audit results to context
+                context['audit'] = True
+                context['audit_results'] = audit_results
+                context['audit_summary'] = {
+                    'total_tools': len(tool_links),
+                    'working_tools': sum(
+                        1 for r in audit_results.values() if r['exists']
+                    ),
+                    'broken_tools': sum(
+                        1 for r in audit_results.values() if not r['exists']
+                    ),
+                }
+
+                # Re-render template with audit results
+                template_str = render_to_string(
+                    'labs/exported.html',
+                    context,
+                    request
+                )
+
+            except Exception as e:
+                logger.error(f"Error during tool auditing: {e}")
+                # Continue with audit error
+                context['audit'] = True
+                context['audit_error'] = str(e)
+                template_str = render_to_string(
+                    'labs/exported.html',
+                    context,
+                    request
+                )
+        else:
+            logger.warning("No galaxy_base_url found for tool auditing")
+            # Still show audit interface with warning
+            context['audit'] = True
+            context['audit_error'] = "No Galaxy server URL found"
+            template_str = render_to_string(
+                'labs/exported.html',
+                context,
+                request
+            )
+    else:
+        # No tool links found, still show audit interface
+        context['audit'] = True
+        context['audit_results'] = {}
+        context['audit_summary'] = {
+            'total_tools': 0,
+            'working_tools': 0,
+            'broken_tools': 0,
+        }
+        template_str = render_to_string(
+            'labs/exported.html',
+            context,
+            request
+        )
+
+    return template_str, context

--- a/app/labs/cache.py
+++ b/app/labs/cache.py
@@ -6,6 +6,7 @@ cache.
 """
 
 import logging
+import os
 from django.conf import settings
 from django.core.cache import cache
 from django.db import IntegrityError
@@ -20,7 +21,8 @@ CACHE_KEY_IGNORE_GET_PARAMS = (
     'cache',
     'nonce',
 )
-NOCACHE = settings.CLI_DEV
+NOCACHE = settings.NOCACHE
+NO_WEB_CACHE = os.getenv('NO_WEB_CACHE', False)  # Development only
 
 logger = logging.getLogger('django.cache')
 
@@ -131,7 +133,7 @@ class WebCache:
 
     @classmethod
     def get(cls, url):
-        if NOCACHE:
+        if NO_WEB_CACHE:
             return
         cache_key = cls._generate_cache_key(url)
         data = cache.get(cache_key)
@@ -140,7 +142,7 @@ class WebCache:
 
     @classmethod
     def put(cls, url, data, timeout=_1_DAY):
-        if NOCACHE:
+        if NO_WEB_CACHE:
             return
         cache_key = cls._generate_cache_key(url)
         cache.set(cache_key, data, timeout=timeout)

--- a/app/labs/static/labs/css/labs.css
+++ b/app/labs/static/labs/css/labs.css
@@ -87,6 +87,9 @@ ul.nav-pills li.nav-item {
 .nav-pills .show>.nav-link {
   background-color: var(--color);
 }
+.nav-pills .nav-link.nav-link-danger {
+  background-color: var(--bs-danger);
+}
 .accordion-button.static::after {
   content: none;
 }

--- a/app/labs/static/labs/css/labs.css
+++ b/app/labs/static/labs/css/labs.css
@@ -88,7 +88,20 @@ ul.nav-pills li.nav-item {
   background-color: var(--color);
 }
 .nav-pills .nav-link.nav-link-danger {
+  color: var(--bs-danger);
+  border: 1px solid var(--bs-danger);
+}
+.nav-pills .nav-link.nav-link-danger .fas  {
+  color: var(--bs-danger);
+}
+.nav-pills .nav-link.active.nav-link-danger,
+.nav-pills .show>.nav-link-danger {
+  color: white;
   background-color: var(--bs-danger);
+}
+.nav-pills .nav-link.active.nav-link-danger .fas,
+.nav-pills .show>.nav-link-danger .fas {
+  color: white;
 }
 .accordion-button.static::after {
   content: none;

--- a/app/labs/static/labs/css/labs.css
+++ b/app/labs/static/labs/css/labs.css
@@ -104,6 +104,16 @@ ul.nav-pills li.nav-item {
   background-color: inherit;
   box-shadow: none;
 }
+.list-group-item-danger .table {
+  color: #842029;
+  margin: 0;
+}
+.list-group-item-danger code {
+  background: transparent;
+  color: #842029;
+  margin: 0;
+  padding: 0;
+}
 
 @media screen and (max-width: 850px) {
   .lab-header {

--- a/app/labs/static/labs/js/audit.js
+++ b/app/labs/static/labs/js/audit.js
@@ -72,7 +72,6 @@ function highlightBrokenToolContainers() {
           if (!tabButton.querySelector('.fa-exclamation-triangle')) {
             const icon = document.createElement('i');
             icon.className = 'fas fa-exclamation-triangle me-2';
-            icon.style.color = 'white';
             tabButton.insertBefore(icon, tabButton.firstChild);
           }
           

--- a/app/labs/static/labs/js/audit.js
+++ b/app/labs/static/labs/js/audit.js
@@ -1,0 +1,116 @@
+/**
+ * Galaxy Lab Tool Audit JavaScript
+ * Handles audit modal display and highlighting of broken tool containers
+ */
+
+// Global variable to store broken tool URLs (set by template)
+window.auditBrokenToolUrls = window.auditBrokenToolUrls || [];
+
+$(document).ready(function() {
+  // Show audit modal on page load
+  $('#auditModal').modal('show');
+  
+  // Highlight tabs and accordions containing broken tool links
+  highlightBrokenToolContainers();
+});
+
+/**
+ * Highlights tab and accordion containers that contain broken tool links
+ */
+function highlightBrokenToolContainers() {
+  const brokenToolUrls = window.auditBrokenToolUrls;
+  
+  console.log('Broken tool URLs:', brokenToolUrls);
+  
+  if (!brokenToolUrls || brokenToolUrls.length === 0) {
+    console.log('No broken tools to highlight');
+    return; // No broken tools, nothing to highlight
+  }
+  
+  // Function to check if an element contains broken tool links
+  function containsBrokenTools(element) {
+    const links = element.querySelectorAll('a[href]');
+    return Array.from(links).some(link => {
+      // Extract tool_id from the link href
+      const urlParams = new URLSearchParams(link.search);
+      const linkToolId = urlParams.get('tool_id');
+      
+      if (!linkToolId) return false;
+      
+      // Check if this tool_id corresponds to any broken tool URL
+      return brokenToolUrls.some(brokenUrl => {
+        try {
+          const brokenUrlParams = new URLSearchParams(new URL(brokenUrl).search);
+          const brokenToolId = brokenUrlParams.get('tool_id');
+          return linkToolId === brokenToolId;
+        } catch (e) {
+          console.warn('Error parsing broken URL:', brokenUrl, e);
+          return false;
+        }
+      });
+    });
+  }
+  
+  // Highlight tab content containers
+  document.querySelectorAll('.tab-content').forEach(tabContent => {
+    const tabPanes = tabContent.querySelectorAll('.tab-pane');
+    
+    tabPanes.forEach(tabPane => {
+      if (containsBrokenTools(tabPane)) {
+        const tabId = tabPane.id;
+        
+        // Find corresponding tab button
+        const tabButton = document.querySelector(
+          `[data-bs-target="#${tabId}"], [href="#${tabId}"]`
+        );
+        if (tabButton) {
+          // Add danger styling to tab button
+          tabButton.classList.add('nav-link-danger');
+          tabButton.style.borderBottomColor = '#dc3545';
+          
+          // Add warning icon
+          if (!tabButton.querySelector('.fa-exclamation-triangle')) {
+            const icon = document.createElement('i');
+            icon.className = 'fas fa-exclamation-triangle me-2';
+            icon.style.color = 'white';
+            tabButton.insertBefore(icon, tabButton.firstChild);
+          }
+          
+          console.log(`Highlighted tab: ${tabId}`);
+        }
+      }
+    });
+  });
+  
+  // Highlight accordion items
+  document.querySelectorAll('.accordion-item').forEach(accordionItem => {
+    const accordionBody = accordionItem.querySelector('.accordion-body');
+    
+    if (accordionBody && containsBrokenTools(accordionBody)) {
+      const accordionButton = accordionItem.querySelector('.accordion-button');
+      
+      if (accordionButton) {
+        // Add danger styling to accordion button
+        accordionButton.classList.add('text-danger');
+        accordionButton.style.borderColor = '#dc3545';
+        
+        // Add warning icon
+        if (!accordionButton.querySelector('.fa-exclamation-triangle')) {
+          const icon = document.createElement('i');
+          icon.className = 'fas fa-exclamation-triangle me-2';
+          icon.style.color = '#dc3545';
+          accordionButton.insertBefore(icon, accordionButton.firstChild);
+        }
+        
+        // Add subtle background color
+        accordionButton.style.backgroundColor = '#f8d7da';
+        
+        const accordionId = accordionButton.getAttribute('aria-controls') ||
+                           accordionButton.getAttribute('data-bs-target');
+        console.log(`Highlighted accordion: ${accordionId}`);
+      }
+    }
+  });
+  
+  console.log(`Highlighted containers with ${brokenToolUrls.length} broken tool links`);
+}

--- a/app/labs/templates/labs/exported.html
+++ b/app/labs/templates/labs/exported.html
@@ -38,10 +38,6 @@
     </span>
   </section>
 
-  {% if audit %}
-  {% include 'labs/snippets/audit.html' %}
-  {% endif %}
-
   <div class="row align-items-center">
     <div class="col">
       {% if snippets.intro_md %}

--- a/app/labs/templates/labs/exported.html
+++ b/app/labs/templates/labs/exported.html
@@ -38,6 +38,10 @@
     </span>
   </section>
 
+  {% if audit %}
+  {% include 'labs/snippets/audit.html' %}
+  {% endif %}
+
   <div class="row align-items-center">
     <div class="col">
       {% if snippets.intro_md %}
@@ -66,6 +70,7 @@
 </main>
 
 
+
 {% if feedback_email %}
 {% include 'labs/components/feedback-modal.html' %}
 {% endif %}
@@ -73,10 +78,6 @@
 
 {% if snippets.footer_md %}
 {{ snippets.footer_md|markdown }}
-{% endif %}
-
-{% if audit %}
-{% include 'labs/snippets/audit.html' %}
 {% endif %}
 
 {% endblock %}

--- a/app/labs/templates/labs/exported.html
+++ b/app/labs/templates/labs/exported.html
@@ -32,6 +32,9 @@
     {% endif %}
     <span id="labName">
       {{ lab_name|upper }}
+      {% if audit %}
+      <span class="text-danger"> - AUDIT</span>
+      {% endif %}
     </span>
   </section>
 

--- a/app/labs/templates/labs/exported.html
+++ b/app/labs/templates/labs/exported.html
@@ -72,6 +72,10 @@
 {{ snippets.footer_md|markdown }}
 {% endif %}
 
+{% if audit %}
+{% include 'labs/snippets/audit-results.html' %}
+{% endif %}
+
 {% endblock %}
 
 

--- a/app/labs/templates/labs/exported.html
+++ b/app/labs/templates/labs/exported.html
@@ -76,7 +76,7 @@
 {% endif %}
 
 {% if audit %}
-{% include 'labs/snippets/audit-results.html' %}
+{% include 'labs/snippets/audit.html' %}
 {% endif %}
 
 {% endblock %}

--- a/app/labs/templates/labs/snippets/audit-results.html
+++ b/app/labs/templates/labs/snippets/audit-results.html
@@ -3,11 +3,12 @@
   Displays the results of backend tool availability checking
 {% endcomment %}
 
-<div id="auditModal" class="modal fade show" tabindex="-1" style="display: block;">
+<div id="auditModal" class="modal fade" tabindex="-1" aria-labelledby="auditModalLabel" aria-hidden="true">
   <div class="modal-dialog modal-lg">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">Tool Audit Results</h5>
+        <h5 class="modal-title" id="auditModalLabel">Tool Audit Results</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
         
@@ -20,7 +21,7 @@
           <!-- Show audit summary -->
           <div class="alert {% if audit_summary.broken_tools == 0 %}alert-success{% else %}alert-warning{% endif %}">
             <strong>Tool Audit Complete:</strong> 
-            {{ audit_summary.working_tools }} of {{ audit_summary.total_tools }} Galaxy tools are available.
+            {{ audit_summary.working_tools }} of {{ audit_summary.total_tools }} linked Galaxy tools are available.
             {% if audit_summary.broken_tools > 0 %}
               {{ audit_summary.broken_tools }} tools are unavailable.
             {% endif %}
@@ -36,15 +37,25 @@
             
           {% else %}
             <!-- Show broken tools -->
-            <h6>Unavailable Tools:</h6>
+            <p class="lead">
+              The following tools could not be fetched. After checking that these tool IDs are correct, you may wish to request installation of these tools on the target Galaxy server, or
+              <a href="/#section_1-faq-7-accordion">exclude them</a>
+              from this galaxy Lab.
+            </p>
             <ul class="list-group">
               {% for tool_id, tool in audit_results.items %}
                 {% if not tool.exists %}
                   <li class="list-group-item list-group-item-danger">
-                    <strong>Tool:</strong> {{ tool.link_text }}<br>
-                    <strong>Tool ID:</strong> <code>{{ tool.tool_id }}</code><br>
-                    <strong>URL:</strong> <code>{{ tool.url }}</code><br>
-                    <small class="text-muted">Error: {{ tool.error }}</small>
+                    <table class="table">
+                      <tr>
+                        <td><strong class="text-nowrap">Tool ID</strong></td>
+                        <td><code>{{ tool.tool_id }}</code></td>
+                      </tr>
+                      <tr>
+                        <td><strong class="text-nowrap">URL</strong></td>
+                        <td><code>{{ tool.url }}</code></td>
+                      </tr>
+                    </table>
                   </li>
                 {% endif %}
               {% endfor %}
@@ -54,17 +65,14 @@
         
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" onclick="closeAuditModal()">Close</button>
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
       </div>
     </div>
   </div>
 </div>
 
 <script>
-function closeAuditModal() {
-  const modal = document.getElementById('auditModal');
-  const backdrop = document.querySelector('.modal-backdrop');
-  if (modal) modal.remove();
-  if (backdrop) backdrop.remove();
-}
+$(document).ready(function() {
+  $('#auditModal').modal('show');
+});
 </script>

--- a/app/labs/templates/labs/snippets/audit-results.html
+++ b/app/labs/templates/labs/snippets/audit-results.html
@@ -1,0 +1,70 @@
+{% comment %}
+  Tool Audit Results Modal
+  Displays the results of backend tool availability checking
+{% endcomment %}
+
+<div id="auditModal" class="modal fade show" tabindex="-1" style="display: block;">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Tool Audit Results</h5>
+      </div>
+      <div class="modal-body">
+        
+        {% if audit_error %}
+          <!-- Show error if audit failed -->
+          <div class="alert alert-danger">
+            <strong>Audit Error:</strong> {{ audit_error }}
+          </div>
+        {% else %}
+          <!-- Show audit summary -->
+          <div class="alert {% if audit_summary.broken_tools == 0 %}alert-success{% else %}alert-warning{% endif %}">
+            <strong>Tool Audit Complete:</strong> 
+            {{ audit_summary.working_tools }} of {{ audit_summary.total_tools }} Galaxy tools are available.
+            {% if audit_summary.broken_tools > 0 %}
+              {{ audit_summary.broken_tools }} tools are unavailable.
+            {% endif %}
+          </div>
+
+          {% if audit_summary.total_tools == 0 %}
+            <!-- No tools found -->
+            <p class="text-info">No Galaxy tool links found on this page.</p>
+            
+          {% elif audit_summary.broken_tools == 0 %}
+            <!-- All tools working -->
+            <p class="text-success">✓ All tools are available on the Galaxy server!</p>
+            
+          {% else %}
+            <!-- Show broken tools -->
+            <h6>Unavailable Tools:</h6>
+            <ul class="list-group">
+              {% for tool_id, tool in audit_results.items %}
+                {% if not tool.exists %}
+                  <li class="list-group-item list-group-item-danger">
+                    <strong>Tool:</strong> {{ tool.link_text }}<br>
+                    <strong>Tool ID:</strong> <code>{{ tool.tool_id }}</code><br>
+                    <strong>URL:</strong> <code>{{ tool.url }}</code><br>
+                    <small class="text-muted">Error: {{ tool.error }}</small>
+                  </li>
+                {% endif %}
+              {% endfor %}
+            </ul>
+          {% endif %}
+        {% endif %}
+        
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" onclick="closeAuditModal()">Close</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+function closeAuditModal() {
+  const modal = document.getElementById('auditModal');
+  const backdrop = document.querySelector('.modal-backdrop');
+  if (modal) modal.remove();
+  if (backdrop) backdrop.remove();
+}
+</script>

--- a/app/labs/templates/labs/snippets/audit.html
+++ b/app/labs/templates/labs/snippets/audit.html
@@ -71,8 +71,21 @@
   </div>
 </div>
 
+{% load static %}
+
 <script>
-$(document).ready(function() {
-  $('#auditModal').modal('show');
-});
+// Set broken tool URLs for the external audit.js script
+{% if audit_results %}
+window.auditBrokenToolUrls = [
+  {% for tool_id, tool in audit_results.items %}
+    {% if not tool.exists %}
+      "{{ tool.url|escapejs }}",
+    {% endif %}
+  {% endfor %}
+];
+{% else %}
+window.auditBrokenToolUrls = [];
+{% endif %}
 </script>
+
+<script src="{% static 'labs/js/audit.js' %}"></script>

--- a/app/labs/templates/labs/snippets/audit.html
+++ b/app/labs/templates/labs/snippets/audit.html
@@ -3,11 +3,29 @@
   Displays the results of backend tool availability checking
 {% endcomment %}
 
+<div class="text-center mt-5 mb-3">
+  <button
+    type="button"
+    class="btn {% if audit_summary.broken_tools == 0 %}btn-success{% else %}btn-danger{% endif %} btn-lg shadow"
+    data-bs-toggle="modal"
+    data-bs-target="#auditModal"
+    title="Show Audit Results"
+  >
+    {% if audit_summary.broken_tools == 0 %}
+      <i class="fas fa-check-circle me-2"></i>
+      Audit success
+    {% else %}
+      <i class="fas fa-exclamation-triangle me-2"></i>
+      Audit issues
+    {% endif %}
+  </button>
+</div>
+
 <div id="auditModal" class="modal fade" tabindex="-1" aria-labelledby="auditModalLabel" aria-hidden="true">
-  <div class="modal-dialog modal-lg">
+  <div class="modal-dialog modal-xl">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title" id="auditModalLabel">Tool Audit Results</h5>
+        <h5 class="modal-title" id="auditModalLabel">Audit Results</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
@@ -20,7 +38,7 @@
         {% else %}
           <!-- Show audit summary -->
           <div class="alert {% if audit_summary.broken_tools == 0 %}alert-success{% else %}alert-warning{% endif %}">
-            <strong>Tool Audit Complete:</strong> 
+            <strong>Audit Complete:</strong>
             {{ audit_summary.working_tools }} of {{ audit_summary.total_tools }} linked Galaxy tools are available.
             {% if audit_summary.broken_tools > 0 %}
               {{ audit_summary.broken_tools }} tools are unavailable.
@@ -40,8 +58,13 @@
             <p class="lead">
               The following tools could not be fetched. After checking that these tool IDs are correct, you may wish to request installation of these tools on the target Galaxy server, or
               <a href="/#section_1-faq-7-accordion">exclude them</a>
-              from this galaxy Lab.
+              from this Galaxy Lab.
             </p>
+
+            <p>
+              Tabs and content items which contain a broken tool link have been highlighted in red in the main page.
+            </p>
+
             <ul class="list-group">
               {% for tool_id, tool in audit_results.items %}
                 {% if not tool.exists %}

--- a/app/labs/tests.py
+++ b/app/labs/tests.py
@@ -1,7 +1,14 @@
 import requests_mock
 from pathlib import Path
+from unittest.mock import Mock, patch
 
 from .lab_export import ExportLabContext
+from .audit import (
+    extract_tool_links,
+    check_tool_exists,
+    audit_tools_concurrent,
+    perform_template_audit,
+)
 from .test.data import (
     MOCK_REQUESTS,
     MOCK_LAB_BASE_URL,
@@ -20,6 +27,20 @@ TEST_LAB_ACCORDION_TEXT = (
 )
 TEST_LAB_CONTENT_URL = f'{MOCK_LAB_BASE_URL}/static/labs/content/docs/base.yml'
 TEST_LAB_URL = f'/?content_root={TEST_LAB_CONTENT_URL}'
+
+# Test constants for audit functionality
+TEST_GALAXY_SERVER_URL = 'https://usegalaxy.org.au'
+# Note: URL decoding converts %2F back to / in parsed URLs
+TEST_VALID_TOOL_ID = 'toolshed.g2.bx.psu.edu/repos/galaxyp/diann/diann'
+TEST_INVALID_TOOL_ID = 'toolshed.g2.bx.psu.edu/repos/galaxyp/blahblah/blahblah'
+TEST_VALID_TOOL_URL = (
+    f'{TEST_GALAXY_SERVER_URL}/?tool_id='
+    'toolshed.g2.bx.psu.edu%2Frepos%2Fgalaxyp%2Fdiann%2Fdiann'
+)
+TEST_INVALID_TOOL_URL = (
+    f'{TEST_GALAXY_SERVER_URL}/?tool_id='
+    'toolshed.g2.bx.psu.edu%2Frepos%2Fgalaxyp%2Fblahblah%2Fblahblah'
+)
 
 
 class LabExportTestCase(TestCase):
@@ -109,3 +130,270 @@ class LabExportTestCase(TestCase):
                 },
             ],
         )
+
+
+class AuditTestCase(TestCase):
+    """Test audit functionality for tool link checking."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.html_with_tools = f'''
+        <html>
+            <body>
+                <a href="{TEST_VALID_TOOL_URL}">Valid Tool</a>
+                <a href="{TEST_INVALID_TOOL_URL}">Invalid Tool</a>
+                <a href="https://example.com">Non-tool Link</a>
+                <a href="{TEST_GALAXY_SERVER_URL}/?tool_id=another_tool">
+                    Another Tool
+                </a>
+            </body>
+        </html>
+        '''
+
+        self.html_without_tools = '''
+        <html>
+            <body>
+                <a href="https://example.com">Regular Link</a>
+                <a href="https://google.com">Another Link</a>
+            </body>
+        </html>
+        '''
+
+    def test_extract_tool_links_finds_valid_tools(self):
+        """Test that extract_tool_links finds all tool links in HTML."""
+        tool_links = extract_tool_links(self.html_with_tools)
+
+        self.assertEqual(len(tool_links), 3)
+
+        # Check that all tool URLs are extracted
+        urls = [link['url'] for link in tool_links]
+        self.assertIn(TEST_VALID_TOOL_URL, urls)
+        self.assertIn(TEST_INVALID_TOOL_URL, urls)
+        expected_another_tool_url = (
+            f'{TEST_GALAXY_SERVER_URL}/?tool_id=another_tool'
+        )
+        self.assertIn(expected_another_tool_url, urls)
+
+        # Check that tool IDs are correctly parsed
+        tool_ids = [link['tool_id'] for link in tool_links]
+        self.assertIn(TEST_VALID_TOOL_ID, tool_ids)
+        self.assertIn(TEST_INVALID_TOOL_ID, tool_ids)
+        self.assertIn('another_tool', tool_ids)
+
+        # Check that link text is extracted
+        link_texts = [link['link_text'] for link in tool_links]
+        self.assertIn('Valid Tool', link_texts)
+        self.assertIn('Invalid Tool', link_texts)
+
+    def test_extract_tool_links_ignores_non_tool_links(self):
+        """Test that extract_tool_links ignores non-tool links."""
+        tool_links = extract_tool_links(self.html_without_tools)
+        self.assertEqual(len(tool_links), 0)
+
+    def test_extract_tool_links_handles_empty_html(self):
+        """Test that extract_tool_links handles empty HTML."""
+        tool_links = extract_tool_links('')
+        self.assertEqual(len(tool_links), 0)
+
+    @patch('labs.audit.GalaxyInstance')
+    def test_check_tool_exists_with_valid_tool(self, mock_galaxy_instance):
+        """Test check_tool_exists with a valid tool."""
+        mock_gi = Mock()
+        mock_galaxy_instance.return_value = mock_gi
+        mock_gi.tools.show_tool.return_value = {'id': TEST_VALID_TOOL_ID}
+
+        tool_id, exists, error = check_tool_exists(
+            TEST_GALAXY_SERVER_URL,
+            TEST_VALID_TOOL_ID
+        )
+
+        self.assertEqual(tool_id, TEST_VALID_TOOL_ID)
+        self.assertTrue(exists)
+        self.assertEqual(error, '')
+        mock_gi.tools.show_tool.assert_called_once_with(TEST_VALID_TOOL_ID)
+
+    @patch('labs.audit.GalaxyInstance')
+    def test_check_tool_exists_with_invalid_tool(self, mock_galaxy_instance):
+        """Test check_tool_exists with an invalid tool."""
+        mock_gi = Mock()
+        mock_galaxy_instance.return_value = mock_gi
+        mock_gi.tools.show_tool.side_effect = Exception(
+            '404 Not Found'
+        )
+
+        tool_id, exists, error = check_tool_exists(
+            TEST_GALAXY_SERVER_URL,
+            TEST_INVALID_TOOL_ID
+        )
+
+        self.assertEqual(tool_id, TEST_INVALID_TOOL_ID)
+        self.assertFalse(exists)
+        self.assertEqual(error, 'Tool not found')
+
+    @patch('labs.audit.GalaxyInstance')
+    def test_check_tool_exists_with_connection_error(
+        self, mock_galaxy_instance
+    ):
+        """Test check_tool_exists with connection error."""
+        mock_galaxy_instance.side_effect = Exception('Connection failed')
+
+        tool_id, exists, error = check_tool_exists(
+            TEST_GALAXY_SERVER_URL,
+            TEST_VALID_TOOL_ID
+        )
+
+        self.assertEqual(tool_id, TEST_VALID_TOOL_ID)
+        self.assertFalse(exists)
+        self.assertIn('Connection error', error)
+
+    @patch('labs.audit.check_tool_exists')
+    def test_audit_tools_concurrent_with_mixed_results(
+        self, mock_check_tool
+    ):
+        """Test audit_tools_concurrent with both valid and invalid tools."""
+        def mock_check_side_effect(galaxy_url, tool_id, api_key=None):
+            del galaxy_url, api_key  # Unused parameters
+            """Mock check_tool_exists to return different results."""
+            if tool_id == TEST_VALID_TOOL_ID:
+                return (tool_id, True, '')
+            else:
+                return (tool_id, False, 'Tool not found')
+
+        tool_links = [
+            {
+                'url': TEST_VALID_TOOL_URL,
+                'tool_id': TEST_VALID_TOOL_ID,
+                'link_text': 'Valid Tool'
+            },
+            {
+                'url': TEST_INVALID_TOOL_URL,
+                'tool_id': TEST_INVALID_TOOL_ID,
+                'link_text': 'Invalid Tool'
+            }
+        ]
+
+        mock_check_tool.side_effect = mock_check_side_effect
+
+        results = audit_tools_concurrent(TEST_GALAXY_SERVER_URL, tool_links)
+
+        self.assertEqual(len(results), 2)
+
+        # Check valid tool result
+        valid_result = results[TEST_VALID_TOOL_ID]
+        self.assertTrue(valid_result['exists'])
+        self.assertEqual(valid_result['error'], '')
+        self.assertEqual(valid_result['link_text'], 'Valid Tool')
+
+        # Check invalid tool result
+        invalid_result = results[TEST_INVALID_TOOL_ID]
+        self.assertFalse(invalid_result['exists'])
+        self.assertEqual(invalid_result['error'], 'Tool not found')
+        self.assertEqual(invalid_result['link_text'], 'Invalid Tool')
+
+    def test_audit_tools_concurrent_with_empty_list(self):
+        """Test audit_tools_concurrent with empty tool list."""
+        results = audit_tools_concurrent(TEST_GALAXY_SERVER_URL, [])
+        self.assertEqual(results, {})
+
+    @patch('labs.audit.render_to_string')
+    def test_perform_template_audit_without_audit_param(self, mock_render):
+        """Test perform_template_audit when audit param is not present."""
+        request = Mock()
+        request.GET = {}
+        context = {'galaxy_base_url': TEST_GALAXY_SERVER_URL}
+        template_str = self.html_with_tools
+
+        result_template, result_context = perform_template_audit(
+            template_str,
+            context,
+            request
+        )
+
+        # Should return unchanged template and context
+        self.assertEqual(result_template, template_str)
+        self.assertEqual(result_context, context)
+        mock_render.assert_not_called()
+
+    @patch('labs.audit.render_to_string')
+    @patch('labs.audit.audit_tools_concurrent')
+    def test_perform_template_audit_with_audit_param(
+        self,
+        mock_audit_tools,
+        mock_render
+    ):
+        """Test perform_template_audit when audit param is present."""
+        request = Mock()
+        request.GET = {'audit': '1'}
+        context = {'galaxy_base_url': TEST_GALAXY_SERVER_URL}
+        template_str = self.html_with_tools
+
+        # Mock audit results for all 3 tools in html_with_tools
+        mock_audit_results = {
+            TEST_VALID_TOOL_ID: {
+                'tool_id': TEST_VALID_TOOL_ID,
+                'exists': True,
+                'error': ''
+            },
+            TEST_INVALID_TOOL_ID: {
+                'tool_id': TEST_INVALID_TOOL_ID,
+                'exists': False,
+                'error': 'Tool not found'
+            },
+            'another_tool': {
+                'tool_id': 'another_tool',
+                'exists': False,
+                'error': 'Tool not found'
+            }
+        }
+        mock_audit_tools.return_value = mock_audit_results
+        mock_render.return_value = 'rendered_template'
+
+        result_template, result_context = perform_template_audit(
+            template_str,
+            context,
+            request
+        )
+
+        # Check that audit flag is set
+        self.assertTrue(result_context['audit'])
+
+        # Check that audit results are in context
+        self.assertEqual(result_context['audit_results'], mock_audit_results)
+
+        # Check that audit summary is calculated
+        # Note: html_with_tools contains 3 tool links
+        expected_summary = {
+            'total_tools': 3,
+            'working_tools': 1,
+            # TEST_INVALID_TOOL_ID and another_tool both fail
+            'broken_tools': 2
+        }
+        self.assertEqual(result_context['audit_summary'], expected_summary)
+
+        # Check that template is re-rendered
+        self.assertEqual(result_template, 'rendered_template')
+        mock_render.assert_called_once()
+
+    @patch('labs.audit.render_to_string')
+    def test_perform_template_audit_with_no_galaxy_url(self, mock_render):
+        """Test perform_template_audit when galaxy_base_url is missing."""
+        request = Mock()
+        request.GET = {'audit': '1'}
+        context = {}  # No galaxy_base_url
+        template_str = self.html_with_tools
+
+        mock_render.return_value = 'rendered_template'
+
+        result_template, result_context = perform_template_audit(
+            template_str,
+            context,
+            request
+        )
+
+        # Should set audit error
+        self.assertTrue(result_context['audit'])
+        self.assertEqual(
+            result_context['audit_error'],
+            'No Galaxy server URL found'
+        )
+        self.assertEqual(result_template, 'rendered_template')

--- a/app/labs/views.py
+++ b/app/labs/views.py
@@ -20,6 +20,7 @@ from .cache import LabCache
 from .forms import LabBootstrapForm
 from .lab_export import ExportLabContext
 from .lab_schema import DEPRECATED_PROPS
+from .audit import perform_template_audit
 
 logger = logging.getLogger('django')
 
@@ -47,6 +48,7 @@ def export_lab(request):
                 'EXAMPLE_LABS': settings.EXAMPLE_LABS,
             })
         context.validate()
+
     except LabBuildError as exc:
         logger.warning(f"Error building lab: {traceback.format_exc()}")
         return render(request, 'labs/export-error.html', {
@@ -70,12 +72,21 @@ def export_lab(request):
             i += 1
     except Exception as exc:
         logger.error(
-            f"Error rendering template for"
-            f" content_root={request.GET.get('content_root')}:"
-            f"\n{traceback.format_exc()}")
+            f"Error rendering template for "
+            f"content_root={request.GET.get('content_root')}: "
+            f"\n{traceback.format_exc()}"
+        )
         return report_exception_response(request, exc)
 
     template_str = context.render_relative_uris(template_str)
+
+    # Perform tool auditing (function checks if audit is requested)
+    template_str, context = perform_template_audit(
+        template_str,
+        context,
+        request
+    )
+
     response = LabCache.put(request, template_str)
 
     return response
@@ -124,7 +135,9 @@ class BootstrapLab(View):
             return response
 
         url = settings.INTERNAL_URL + str(relpath).strip('/')
-        logger.debug('Serving file via Nginx X-Accel-Redirect: %s' % relpath)
+        logger.debug(
+            'Serving file via Nginx X-Accel-Redirect: %s' % relpath
+        )
         response = HttpResponse()
         response['Content-Type'] = ''
         response['Content-Disposition'] = "attachment; filename=lab.zip"

--- a/app/labs/views.py
+++ b/app/labs/views.py
@@ -56,6 +56,8 @@ def export_lab(request):
             'deprecated_props': DEPRECATED_PROPS,
         }, status=400)
 
+    context['audit'] = 'audit' in request.GET
+
     # Multiple rounds of templating to render recursive template tags from
     # remote data with embedded template tags
     try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,6 @@ django_light
 requests==2.*
 requests_mock==1.*
 sentry-sdk==2.*
+bioblend==1.*
 django-crispy-forms==2.*
 crispy-bootstrap5==2024.*


### PR DESCRIPTION
- Observe GET param `audit` to perform an audit of tool links if the param exists
- For each tool link, parse tool ID and check for existence on Galaxy server with bioblend
- Show broken tool link results in the returned webpage 